### PR TITLE
Case sensitivity fix + freshening FreeRTOS macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(COMPONENT_ADD_INCLUDEDIRS driver/include)
 set(COMPONENT_PRIV_INCLUDEDIRS driver/private_include)
 set(COMPONENT_REQUIRES driver)
-set(COMPONENT_SRCS driver/hd44780.c)
+set(COMPONENT_SRCS driver/HD44780.c)
 register_component()

--- a/examples/lcd_tools/main/cmd_lcd_tools.c
+++ b/examples/lcd_tools/main/cmd_lcd_tools.c
@@ -163,7 +163,7 @@ static int do_lcd_detect_cmd(int argc, char **argv)
             i2c_master_start(cmd);
             i2c_master_write_byte(cmd, (address << 1) | WRITE_BIT, ACK_CHECK_EN);
             i2c_master_stop(cmd);
-            esp_err_t ret = i2c_master_cmd_begin(lcd_handle.i2c_port, cmd, 50 / portTICK_RATE_MS);
+            esp_err_t ret = i2c_master_cmd_begin(lcd_handle.i2c_port, cmd, 50 / portTICK_PERIOD_MS);
             i2c_cmd_link_delete(cmd);
             if (ret == ESP_OK)
             {


### PR DESCRIPTION
Hi, firstly thanks for this library - it's just what I was looking for!

I fixed up the casing of the reference to the HD44780.c file so that it would compile on my Debian workstation
Also, there was a deprecated FreeRTOS macro which made esp-idf v5.0 unhappy, so I updated that

Keep up the good work!